### PR TITLE
124 js 0240 use shorthand property syntax for object literals

### DIFF
--- a/src/pages/api/pricing/pay.js
+++ b/src/pages/api/pricing/pay.js
@@ -32,10 +32,10 @@ export default async function handler(req, res) {
 
     const { result } = await paymentsApi.createPayment({
       idempotencyKey: randomUUID(),
-      sourceId: sourceId,
+      sourceId,
       amountMoney: {
         currency: `USD`,
-        amount: amount,
+        amount,
       },
     })
 


### PR DESCRIPTION
Since we have `const { sourceId, amount } = req.body` on line 23, we can use these properties as shorthand properties 